### PR TITLE
libuzfs & uzfs: use zfs sa to implement attr/xattr and add tools to test it

### DIFF
--- a/cmd/uzfs/uzfs.c
+++ b/cmd/uzfs/uzfs.c
@@ -37,6 +37,9 @@
 #include <sys/zfs_context.h>
 #include <libuzfs.h>
 #include <pthread.h>
+#include <libuzfs_impl.h>
+#include <sys/nvpair.h>
+#include <umem.h>
 
 static int uzfs_zpool_create(int argc, char **argv);
 static int uzfs_zpool_destroy(int argc, char **argv);
@@ -88,6 +91,7 @@ static int uzfs_inode_get_kvobj(int argc, char **argv);
 static int uzfs_inode_get_kvattr(int argc, char **argv);
 static int uzfs_inode_set_kvattr(int argc, char **argv);
 static int uzfs_inode_rm_kvattr(int argc, char **argv);
+static int uzfs_attr_random_test(int argc, char **argv);
 
 static int uzfs_dentry_create(int argc, char **argv);
 static int uzfs_dentry_delete(int argc, char **argv);
@@ -138,6 +142,7 @@ typedef enum {
 	HELP_DENTRY_CREATE,
 	HELP_DENTRY_DELETE,
 	HELP_DENTRY_LOOKUP,
+    HELP_ATTR_TEST,
 } uzfs_help_t;
 
 typedef struct uzfs_command {
@@ -200,6 +205,7 @@ static uzfs_command_t command_table[] = {
 	{ "create-dentry",	uzfs_dentry_create, 	HELP_DENTRY_CREATE  },
 	{ "delete-dentry",	uzfs_dentry_delete, 	HELP_DENTRY_DELETE  },
 	{ "lookup-dentry",	uzfs_dentry_lookup, 	HELP_DENTRY_DELETE  },
+    { "attr-test",      uzfs_attr_random_test,  HELP_ATTR_TEST},
 };
 
 #define	NCOMMAND	(sizeof (command_table) / sizeof (command_table[0]))
@@ -298,6 +304,8 @@ get_usage(uzfs_help_t idx)
 		return (gettext("\tdelete-dentry ...\n"));
 	case HELP_DENTRY_LOOKUP:
 		return (gettext("\tlookup-dentry ...\n"));
+    case HELP_ATTR_TEST:
+        return (gettext("\tattr-test ...\n"));
 	default:
 		__builtin_unreachable();
 	}
@@ -361,6 +369,38 @@ static void print_stat(const char* name, struct stat* stat)
 
     printf(format, name, type, stat->st_ino, stat->st_mode, stat->st_nlink, stat->st_uid, stat->st_gid,
            stat->st_size, stat->st_blksize, stat->st_blocks);
+}
+
+static void print_stat_sa(const char* name, uzfs_attr_t* stat)
+{
+    const char* format =
+        "ino: %lu\n"
+        "pino: %lu\n"
+        "psid: %u\n"
+        "ftype: %d\n"
+        "gen: %lu\n"
+        "nlink: %u\n"
+        "perm: %u\n"
+        "uid: %u\n"
+        "gid: %u\n"
+        "size: %lu\n"
+        "blksize: %lu\n"
+        "blocks: %lu\n"
+        "nsid: %lu\n"
+        "atime: (%lu, %lu)\n"
+        "mtime: (%lu, %lu)\n"
+        "ctime: (%lu, %lu)\n"
+        "btime: (%lu, %lu)\n"
+        ;
+
+    printf(format, stat->ino, stat->pino, stat->psid,
+           stat->ftype, stat->gen, stat->nlink, stat->perm,
+           stat->uid, stat->gid, stat->size, stat->blksize,
+           stat->blocks, stat->nsid, stat->atime.tv_sec,
+           stat->atime.tv_nsec, stat->mtime.tv_sec,
+           stat->mtime.tv_nsec, stat->ctime.tv_sec,
+           stat->ctime.tv_nsec, stat->btime.tv_sec,
+           stat->btime.tv_nsec);
 }
 
 static int
@@ -1046,14 +1086,14 @@ uzfs_inode_getattr(int argc, char **argv)
 		return (-1);
 	}
 
-	struct stat buf;
+	uzfs_attr_t buf;
 	memset(&buf, 0, sizeof(buf));
 
 	err = libuzfs_inode_getattr(dhp, obj, &buf, sizeof(buf));
 	if (err)
 		printf("failed to get attr inode %ld on dataset: %s\n", obj, dsname);
 	else
-		print_stat(NULL, &buf);
+		print_stat_sa(NULL, &buf);
 
 	libuzfs_dataset_close(dhp);
 
@@ -1074,28 +1114,30 @@ uzfs_inode_setattr(int argc, char **argv)
 		printf("failed to open dataset: %s\n", dsname);
 		return (-1);
 	}
+	uint64_t opid = libuzfs_get_max_synced_opid(dhp) + 1;
 
-	struct stat buf;
+	uzfs_attr_t buf;
 	memset(&buf, 0, sizeof(buf));
 
-	buf.st_ino = obj;
-	buf.st_mode = 0x1;
-	buf.st_nlink = 1;
-	buf.st_uid = 0;
-	buf.st_gid = 0;
-	buf.st_size = 4096;
-//	buf.st_atime.tv_sec = 0;
-//	buf.st_mtime.tv_sec = 0;
-//	buf.st_ctime.tv_sec = 0;
-	buf.st_blocks = 8;
-	buf.st_blksize = 512;
+    buf.ino = obj;
+    buf.pino = 0;
+    buf.psid = 0;
+    buf.ftype = TYPE_FILE;
+    buf.gen = opid;
+    buf.nlink = 1;
+    buf.perm = 0;
+    buf.uid = 12358;
+    buf.gid = 85321;
+    buf.size = 0;
+    buf.blksize = 65536;
+    buf.blocks = 1;
+    buf.nsid = 1;
 
-	uint64_t opid = libuzfs_get_max_synced_opid(dhp) + 1;
 	err = libuzfs_inode_setattr(dhp, obj, &buf, sizeof(buf), opid);
 	if (err)
 		printf("failed to get attr inode %ld on dataset: %s\n", obj, dsname);
 	else
-		print_stat(NULL, &buf);
+		print_stat_sa(NULL, &buf);
 
 	libuzfs_dataset_close(dhp);
 
@@ -1210,6 +1252,202 @@ uzfs_inode_rm_kvattr(int argc, char **argv)
 	libuzfs_dataset_close(dhp);
 
 	return (err);
+}
+
+static int
+uzfs_attr_cmp(uzfs_attr_t *lhs, uzfs_attr_t *rhs)
+{
+    return lhs->ino == rhs->ino && lhs->pino == rhs->pino &&
+           lhs->psid == rhs->psid && lhs->ftype == rhs->ftype &&
+           lhs->gen == rhs->gen && lhs->nlink == rhs->nlink &&
+           lhs->perm == rhs->perm && lhs->gid == rhs->gid &&
+           lhs->size == rhs->size && lhs->blksize == rhs->blksize &&
+           lhs->blocks == rhs->blocks && lhs->nsid == rhs->nsid &&
+           lhs->atime.tv_nsec == rhs->atime.tv_nsec && lhs->atime.tv_sec == rhs->atime.tv_sec &&
+           lhs->mtime.tv_nsec == rhs->mtime.tv_nsec && lhs->mtime.tv_sec == rhs->mtime.tv_sec &&
+           lhs->ctime.tv_nsec == rhs->ctime.tv_nsec && lhs->ctime.tv_sec == rhs->ctime.tv_sec &&
+           lhs->btime.tv_nsec == rhs->btime.tv_nsec && lhs->btime.tv_sec == rhs->btime.tv_sec;
+}
+
+static boolean_t
+uzfs_attr_ops (libuzfs_dataset_handle_t *dhp, uint64_t *ino,
+               libuzfs_inode_type_t *type, uzfs_attr_t *cur_attr,
+               nvlist_t *nvl, boolean_t *reset)
+{
+    int delete_proportion = 1;
+    int getkvattr_proportion = 2;
+    int setkvattr_proportion = 4;
+    int deletekvattr_proportion = 1;
+    int getattr_proportion = 6;
+    int setattr_proportion = 6;
+    int op = rand() % 20;
+    *reset = B_FALSE;
+    if (op < delete_proportion) {
+        // delete inode
+        if (*ino != 0) {
+            VERIFY0(libuzfs_inode_delete(dhp, *ino, *type, 0));
+            memset(cur_attr, 0, sizeof(*cur_attr));
+            // printf("delete inode: %lu\n", *ino);
+            *ino = 0;
+            *reset = B_TRUE;
+        }
+        return B_TRUE;
+    }
+    op -= delete_proportion;
+
+    if (*ino == 0) {
+        boolean_t claiming = B_FALSE;
+        if (claiming) {
+            *ino = 2;
+        }
+        *type = rand() % 2;
+        VERIFY0(libuzfs_create_inode_with_type(dhp, ino, claiming, *type, 0));
+    }
+    if (op < getkvattr_proportion) {
+        // get all kvattr and check
+        nvpair_t *elem = NULL;
+        while ((elem = nvlist_next_nvpair(nvl, elem)) != NULL) {
+            char *name = nvpair_name(elem);
+            char *value = NULL;
+            uint_t size;
+            VERIFY0(nvpair_value_byte_array(elem, (uchar_t **)(&value), &size));
+            char *stored_value = (char *)umem_alloc(size, UMEM_NOFAIL);
+            VERIFY0(libuzfs_inode_get_kvattr(dhp, *ino, name, stored_value, (uint64_t)(size), 0));
+            if(memcmp(value, stored_value, size) != 0) {
+                // printf("name: %s, value[0]: %c, stored_value[0]: %c\n", name, value[0], stored_value[0]);
+                return B_FALSE;
+            }
+            umem_free(stored_value, size);
+        }
+        // printf("get ok\n");s
+        return B_TRUE;
+    }
+    op -= getkvattr_proportion;
+
+    if (op < setkvattr_proportion) {
+        char *name = NULL;
+        int name_size = 0;
+        if (rand() % 4 < 1) {
+            nvpair_t *elem = NULL;
+            if ((elem = nvlist_next_nvpair(nvl, elem)) != NULL) {
+                name = nvpair_name(elem);
+            }
+        }
+        if (name == NULL) {
+            name_size = rand() % 50 + 1;
+            name = umem_alloc(name_size + 1, UMEM_NOFAIL);
+            for (int i = 0; i < name_size; ++i) {
+                name[i] = rand() % 26 + 'a';
+            }
+            name[name_size] = '\0';
+        }
+
+        uint_t value_size = rand() % 32768 + 100;
+        uchar_t *value = umem_alloc(value_size + 1, UMEM_NOFAIL);
+        for (int i = 0; i < value_size; ++i) {
+            value[i] = rand() % 26 + 'a';
+        }
+        value[value_size] = '\0';
+
+        // printf("setkvattr: name: %s, value_size: %u, start_char, %c\n", name, value_size + 1, value[0]);
+        VERIFY0(libuzfs_inode_set_kvattr(dhp, *ino, name, (char *)value, value_size + 1, 0, 0));
+        VERIFY0(nvlist_add_byte_array(nvl, name, value, value_size + 1));
+        umem_free(value, value_size + 1);
+        if (name_size > 0) {
+            umem_free(name, name_size + 1);
+        }
+        return B_TRUE;
+    }
+    op -= setkvattr_proportion;
+
+    if (op < deletekvattr_proportion) {
+        // delete one kv_attr
+        nvpair_t *elem = NULL;
+        if ((elem = nvlist_next_nvpair(nvl, elem)) != NULL) {
+            char *name = nvpair_name(elem);
+            // printf("remove kvattr, name: %s\n", name);
+            int err = libuzfs_inode_remove_kvattr(dhp, *ino, name, 0);
+            if (err != 0) {
+                printf("remove kvattr, name: %s, failed, err: %d\n", name, err);
+                return B_FALSE;
+            }
+            VERIFY0(nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY));
+        }
+        return B_TRUE;
+    }
+    op -= deletekvattr_proportion;
+
+    if (op < getattr_proportion) {
+        // get attr
+        uzfs_attr_t stored_attr;
+        VERIFY0(libuzfs_inode_getattr(dhp, *ino, &stored_attr, sizeof(stored_attr)));
+        if(uzfs_attr_cmp(&stored_attr, cur_attr) == 0) {
+            printf("cur_attr: \n");
+            print_stat_sa(NULL, cur_attr);
+            printf("stored_attr: \n");
+            print_stat_sa(NULL, &stored_attr);
+            printf("\n");
+            return B_FALSE;
+        }
+        // printf("get ok\n");
+        return B_TRUE;
+    }
+    op -= getattr_proportion;
+
+    if (op < setattr_proportion){
+        // set attr
+        // change 4 byte of cur_attr and set
+        // printf("set attr\n");
+        int attr_size = sizeof(uzfs_attr_t);
+        int start_index = rand() % (attr_size - 3);
+        for (int i =  start_index; i < start_index + 4; ++i) {
+            ((uchar_t *)(cur_attr))[i] = rand() % 256;
+        }
+        VERIFY0(libuzfs_inode_setattr(dhp, *ino, cur_attr, sizeof(uzfs_attr_t), 0));
+        return B_TRUE;
+    }
+    return B_TRUE;
+}
+
+static int
+uzfs_attr_random_test(int argc, char **argv)
+{
+    assert(argc == 3);
+    char *dsname = argv[1];
+    libuzfs_dataset_handle_t *dhp = libuzfs_dataset_open(dsname);
+	if (!dhp) {
+		printf("failed to open dataset: %s\n", dsname);
+		return (-1);
+	}
+
+    int nloops = atoi(argv[2]);
+    uint64_t ino = 0;
+    uzfs_attr_t cur_attr;
+    memset(&cur_attr, 0, sizeof(cur_attr));
+    nvlist_t *nvl = NULL;
+    VERIFY0(nvlist_alloc(&nvl, NV_UNIQUE_NAME, KM_SLEEP));
+    libuzfs_inode_type_t type = 0;
+    int seed = time(NULL);
+    srand(seed);
+    printf("testing attr functionalities, loops: %d, seed: %d\n", nloops, seed);
+    for (int i = 0; i < nloops; ++i) {
+        boolean_t reset;
+        if (!uzfs_attr_ops(dhp, &ino, &type, &cur_attr, nvl, &reset)) {
+            printf("test failed, total loops: %d\n", i);
+            break;
+        }
+        if (reset) {
+            nvlist_free(nvl);
+            VERIFY0(nvlist_alloc(&nvl, NV_UNIQUE_NAME, KM_SLEEP));
+        }
+    }
+    if (ino != 0) {
+        VERIFY0(libuzfs_inode_delete(dhp, ino, type, 0));
+    }
+    nvlist_free(nvl);
+    libuzfs_dataset_close(dhp);
+    printf("test end\n");
+    return 0;
 }
 
 int

--- a/cmd/zfs_fuse/zfs_fuse.c
+++ b/cmd/zfs_fuse/zfs_fuse.c
@@ -14,7 +14,7 @@
 
 #define FUSE_USE_VERSION 30
 
-#include <fuse_lowlevel.h>
+#include <fuse3/fuse_lowlevel.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,7 +22,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <assert.h>
-#include <fuse.h>
+#include <fuse3/fuse.h>
 #include <libuzfs.h>
 
 struct zfs_fuse_conf_t {

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -168,15 +168,16 @@ extern int libuzfs_create_inode_with_type(libuzfs_dataset_handle_t *dhp, uint64_
 extern int libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino,
                                 libuzfs_inode_type_t type, uint64_t opid);
 extern int libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    void *attr, uint64_t size);
+                                 void *attr, uint64_t size);
 extern int libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const void *attr, uint64_t size, uint64_t opid);
+                                 const void *attr, uint64_t size, uint64_t opid);
 extern int libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const char *name, const char *value, uint64_t size, int flags, uint64_t opid);
+                                    const char *name, const char *value, 
+                                    uint64_t size, int flags, uint64_t opid);
 extern int libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const char *name, char *value, uint64_t size, int flags);
-extern int libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp,
-    uint64_t ino, const char *name, uint64_t opid);
+                                    const char *name, char *value, uint64_t size, int flags);
+extern int libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+                                       const char *name, uint64_t opid);
 
 #ifdef	__cplusplus
 }

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -130,26 +130,8 @@ extern int libuzfs_inode_create(libuzfs_dataset_handle_t *dhp, uint64_t *ino,
 extern int libuzfs_inode_claim(libuzfs_dataset_handle_t *dhp, uint64_t ino,
     libuzfs_inode_type_t type);
 
-extern int libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    libuzfs_inode_type_t type, uint64_t opid);
-
-extern int libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    void *attr, uint64_t size);
-
-extern int libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const void *attr, uint64_t size, uint64_t opid);
-
 extern int libuzfs_inode_get_kvobj(libuzfs_dataset_handle_t *dhp,
     uint64_t ino, uint64_t *kvobj);
-
-extern int libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const char *name, const char *value, uint64_t size, int flags, uint64_t opid);
-
-extern int libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const char *name, char *value, uint64_t size, int flags);
-
-extern int libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp,
-    uint64_t ino, const char *name, uint64_t opid);
 
 extern int libuzfs_dentry_create(libuzfs_dataset_handle_t *dhp, uint64_t dino,
     const char *name, uint64_t *value, uint64_t num, uint64_t opid);
@@ -177,6 +159,24 @@ extern int libuzfs_rename(uint64_t fsid, uint64_t sdino, char* sname, uint64_t t
 extern int libuzfs_read(uint64_t fsid, uint64_t ino, zfs_uio_t *uio, int ioflag);
 extern int libuzfs_write(uint64_t fsid, uint64_t ino, zfs_uio_t *uio, int ioflag);
 extern int libuzfs_fsync(uint64_t fsid, uint64_t ino, int syncflag);
+
+extern void libuzfs_create_objset_attr(objset_t *os, dmu_tx_t *tx);
+extern void libuzfs_open_dataset_attr(libuzfs_dataset_handle_t *dhp);
+extern int libuzfs_create_inode_with_type(libuzfs_dataset_handle_t *dhp, uint64_t *obj,
+                                          boolean_t claiming, libuzfs_inode_type_t type, 
+                                          uint64_t opid);
+extern int libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+                                libuzfs_inode_type_t type, uint64_t opid);
+extern int libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    void *attr, uint64_t size);
+extern int libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    const void *attr, uint64_t size, uint64_t opid);
+extern int libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    const char *name, const char *value, uint64_t size, int flags, uint64_t opid);
+extern int libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    const char *name, char *value, uint64_t size, int flags);
+extern int libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp,
+    uint64_t ino, const char *name, uint64_t opid);
 
 #ifdef	__cplusplus
 }

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -40,6 +40,7 @@ typedef enum {
 
 typedef struct libuzfs_zpool_handle libuzfs_zpool_handle_t;
 typedef struct libuzfs_dataset_handle libuzfs_dataset_handle_t;
+typedef struct uzfs_attr uzfs_attr_t;
 
 typedef int (*filldir_t)(void *, const char *, int, loff_t, u64, unsigned);
 

--- a/include/libuzfs_impl.h
+++ b/include/libuzfs_impl.h
@@ -31,6 +31,7 @@
 #include <sys/zfs_context.h>
 #include <sys/spa.h>
 #include <sys/dmu.h>
+#include <sys/sa.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -48,6 +49,35 @@ struct libuzfs_dataset_handle {
 	sa_attr_type_t	*uzfs_attr_table;
 };
 
+typedef enum {
+    TYPE_FILE,
+    TYPE_DIR,
+    TYPE_SYMLINK,
+    TYPE_SOCK,
+    TYPE_FIFO,
+    TYPE_CHR,
+    TYPE_BLK
+} FileType;
+
+struct uzfs_attr{
+    uint64_t ino;
+    uint64_t pino;
+    uint32_t psid;
+    FileType ftype;
+    uint64_t gen;
+    uint32_t nlink;
+    uint32_t perm;
+    uint32_t uid;
+    uint32_t gid;
+    uint64_t size;
+    uint64_t blksize;
+    uint64_t blocks;
+    uint32_t nsid;
+    struct timespec atime;
+    struct timespec mtime;
+    struct timespec ctime;
+    struct timespec btime;
+};
 
 #ifdef	__cplusplus
 }

--- a/include/libuzfs_impl.h
+++ b/include/libuzfs_impl.h
@@ -45,6 +45,7 @@ struct libuzfs_dataset_handle {
 	char name[ZFS_MAX_DATASET_NAME_LEN];
 	objset_t *os;
 	zilog_t	*zilog;
+	sa_attr_type_t	*uzfs_attr_table;
 };
 
 

--- a/lib/libuzfs/Makefile.am
+++ b/lib/libuzfs/Makefile.am
@@ -14,7 +14,9 @@ pkgconfig_DATA = libuzfs.pc
 
 lib_LTLIBRARIES = libuzfs.la
 
-USER_C = libuzfs.c
+USER_C = \
+    libuzfs.c \
+    libuzfs_attr.c
 
 libuzfs_la_SOURCES = $(USER_C)
 

--- a/lib/libuzfs/libuzfs.c
+++ b/lib/libuzfs/libuzfs.c
@@ -414,6 +414,7 @@ out:
 static void
 libuzfs_objset_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 {
+	libuzfs_create_objset_attr(os, tx); 
 }
 
 int
@@ -490,6 +491,7 @@ libuzfs_dataset_open(const char *dsname)
 
 	zilog = zil_open(os, libuzfs_get_data);
 
+	libuzfs_open_dataset_attr(dhp);
 	return (dhp);
 }
 
@@ -497,6 +499,9 @@ void
 libuzfs_dataset_close(libuzfs_dataset_handle_t *dhp)
 {
 	zil_close(dhp->zilog);
+	if(dhp->os->os_sa != NULL) {
+		sa_tear_down(dhp->os);
+	}
 	dmu_objset_disown(dhp->os, B_TRUE, dhp);
 	libuzfs_dhp_fini(dhp);
 	free(dhp);
@@ -537,35 +542,7 @@ void libuzfs_wait_synced(libuzfs_dataset_handle_t *dhp) {
 int
 libuzfs_object_create(libuzfs_dataset_handle_t *dhp, uint64_t *obj, uint64_t opid)
 {
-	int err = 0;
-	dmu_tx_t *tx = NULL;
-	objset_t *os = dhp->os;
-
-	tx = dmu_tx_create(os);
-
-	dmu_tx_hold_bonus(tx, DMU_NEW_OBJECT);
-
-	err = dmu_tx_assign(tx, TXG_WAIT);
-	if (err) {
-		dmu_tx_abort(tx);
-		goto out;
-	}
-
-	int dnodesize = dmu_objset_dnodesize(os);
-	int bonuslen = DN_BONUS_SIZE(dnodesize);
-	int blocksize = 0;
-	int ibshift = 0;
-
-	*obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
-	    DMU_OT_PLAIN_OTHER, bonuslen, dnodesize, tx);
-
-	VERIFY0(dmu_object_set_blocksize(os, *obj, blocksize, ibshift, tx));
-
-	dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-	dmu_tx_commit(tx);
-
-out:
-	return (err);
+	return libuzfs_create_inode_with_type(dhp, obj, B_FALSE, INODE_FILE, opid);
 }
 
 int
@@ -597,36 +574,7 @@ out:
 int
 libuzfs_object_claim(libuzfs_dataset_handle_t *dhp, uint64_t obj)
 {
-	int err = 0;
-	dmu_tx_t *tx = NULL;
-	objset_t *os = dhp->os;
-
-	int dnodesize = dmu_objset_dnodesize(os);
-	int bonuslen = DN_BONUS_SIZE(dnodesize);
-	int blocksize = 0;
-	int ibs = 0;
-
-	tx = dmu_tx_create(os);
-
-	dmu_tx_hold_bonus(tx, DMU_NEW_OBJECT);
-
-	err = dmu_tx_assign(tx, TXG_WAIT);
-	if (err) {
-		dmu_tx_abort(tx);
-		goto out;
-	}
-
-	err = dmu_object_claim_dnsize(os, obj, DMU_OT_PLAIN_FILE_CONTENTS, 0,
-		DMU_OT_PLAIN_OTHER, bonuslen, dnodesize, tx);
-	if (err)
-		goto out;
-
-	VERIFY0(dmu_object_set_blocksize(os, obj, blocksize, ibs, tx));
-
-	dmu_tx_commit(tx);
-
-out:
-	return (err);
+	return libuzfs_create_inode_with_type(dhp, &obj, B_TRUE, INODE_FILE, 0);
 }
 
 int
@@ -989,137 +937,12 @@ libuzfs_zap_count(libuzfs_dataset_handle_t *dhp, uint64_t obj, uint64_t *count)
 
 int libuzfs_inode_create(libuzfs_dataset_handle_t *dhp, uint64_t *ino, libuzfs_inode_type_t type, uint64_t opid)
 {
-	if (type == INODE_FILE)
-		return libuzfs_object_create(dhp, ino, opid);
-
-	if (type == INODE_DIR)
-		return libuzfs_zap_create(dhp, ino, opid);
-
-	return EINVAL;
+	return libuzfs_create_inode_with_type(dhp, ino, B_FALSE, type, opid);
 }
 
 int libuzfs_inode_claim(libuzfs_dataset_handle_t *dhp, uint64_t ino, libuzfs_inode_type_t type)
 {
-	if (type == INODE_FILE)
-		return libuzfs_object_claim(dhp, ino);
-
-	if (type == INODE_DIR)
-		return libuzfs_zap_claim(dhp, ino);
-
-	return EINVAL;
-}
-
-static int
-libuzfs_inode_kvobj_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino, libuzfs_inode_type_t type,
-    uint64_t kvobj, uint64_t opid)
-{
-	int err = 0;
-	dmu_tx_t *tx = NULL;
-	objset_t *os = dhp->os;
-
-	tx = dmu_tx_create(os);
-
-	dmu_tx_hold_free(tx, kvobj, 0, DMU_OBJECT_END);
-	dmu_tx_hold_free(tx, ino, 0, DMU_OBJECT_END);
-
-	err = dmu_tx_assign(tx, TXG_WAIT);
-	if (err) {
-		dmu_tx_abort(tx);
-		goto out;
-	}
-
-	VERIFY0(zap_destroy(os, kvobj, tx));
-
-	if (type == INODE_FILE)
-		VERIFY0(dmu_object_free(os, ino, tx));
-	else if (type == INODE_DIR)
-		VERIFY0(zap_destroy(os, ino, tx));
-
-	dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-	dmu_tx_commit(tx);
-
-out:
-	return (err);
-}
-
-int
-libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino, libuzfs_inode_type_t type,
-    uint64_t opid)
-{
-	if (type != INODE_FILE && type != INODE_DIR)
-		return EINVAL;
-
-	uint64_t kvobj = 0;
-	VERIFY0(libuzfs_inode_get_kvobj(dhp, ino, &kvobj));
-
-	if (kvobj == 0) {
-		if (type == INODE_FILE)
-			return libuzfs_object_delete(dhp, ino, opid);
-		if (type == INODE_DIR)
-			return libuzfs_zap_delete(dhp, ino, opid);
-	}
-
-	return libuzfs_inode_kvobj_delete(dhp, ino, type, kvobj, opid);
-}
-
-int
-libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino, void *attr, uint64_t size)
-{
-	return libuzfs_object_getattr(dhp, ino, attr, size);
-}
-
-int
-libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino, const void *attr, uint64_t size,
-    uint64_t opid)
-{
-	return libuzfs_object_setattr(dhp, ino, attr, size, opid);
-}
-
-static int
-libuzfs_object_kvattr_create_add(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    const char *key, const char *value, uint64_t size, int flags, uint64_t opid)
-{
-	int err = 0;
-	dmu_tx_t *tx = NULL;
-	objset_t *os = dhp->os;
-	dmu_buf_t *db;
-	uint64_t kvobj = 0;
-
-	tx = dmu_tx_create(os);
-
-	dmu_tx_hold_zap(tx, DMU_NEW_OBJECT, B_TRUE, NULL);
-	dmu_tx_hold_bonus(tx, ino);
-
-	err = dmu_tx_assign(tx, TXG_WAIT);
-	if (err) {
-		dmu_tx_abort(tx);
-		goto out;
-	}
-
-	int dnodesize = dmu_objset_dnodesize(os);
-	int bonuslen = DN_BONUS_SIZE(dnodesize);
-
-	kvobj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS,
-	    DMU_OT_PLAIN_OTHER, bonuslen, dnodesize, tx);
-
-	err = zap_add(os, kvobj, key, 1, size, value, tx);
-	if (err) {
-		dmu_tx_abort(tx);
-		goto out;
-	}
-
-	VERIFY0(dmu_bonus_hold(os, ino, FTAG, &db));
-	dmu_buf_will_dirty(db, tx);
-	bcopy(&kvobj, db->db_data, sizeof(kvobj));
-	dmu_buf_rele(db, FTAG);
-
-	dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-	dmu_tx_commit(tx);
-
-	libuzfs_wait_synced(dhp);
-
-out:
-	return (err);
+	return libuzfs_create_inode_with_type(dhp, &ino, B_FALSE, type, 0);
 }
 
 int
@@ -1132,58 +955,6 @@ libuzfs_inode_get_kvobj(libuzfs_dataset_handle_t *dhp, uint64_t ino, uint64_t *k
 	dmu_buf_rele(db, FTAG);
 
 	return 0;
-}
-
-int
-libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino, const char *name,
-    char *value, uint64_t size, int flags)
-{
-	int err = 0;
-	uint64_t kvobj;
-
-	err = libuzfs_inode_get_kvobj(dhp, ino, &kvobj);
-	if (err)
-		return err;
-
-	if (kvobj == 0)
-		return ENOENT;
-
-	return libuzfs_zap_lookup(dhp, kvobj, name, 1, size, value);
-}
-
-// TODO(hping): remove kvobj when no kv attr
-int
-libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino, const char *name,
-    uint64_t opid)
-{
-	int err = 0;
-	uint64_t kvobj;
-
-	err = libuzfs_inode_get_kvobj(dhp, ino, &kvobj);
-	if (err)
-		return err;
-
-	if (kvobj == 0)
-		return ENOENT;
-
-	return libuzfs_zap_remove(dhp, kvobj, name, opid);
-}
-
-int
-libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino, const char *name,
-    const char *value, uint64_t size, int flags, uint64_t opid)
-{
-	int err = 0;
-	uint64_t kvobj;
-
-	err = libuzfs_inode_get_kvobj(dhp, ino, &kvobj);
-	if (err)
-		return err;
-
-	if (kvobj == 0)
-		return libuzfs_object_kvattr_create_add(dhp, ino, name, value, size, flags, opid);
-
-	return libuzfs_zap_update(dhp, kvobj, name, 1, size, value, opid);
 }
 
 int libuzfs_dentry_create(libuzfs_dataset_handle_t *dhp, uint64_t dino, const char *name,

--- a/lib/libuzfs/libuzfs_attr.c
+++ b/lib/libuzfs/libuzfs_attr.c
@@ -1,0 +1,663 @@
+#include <sys/avl.h>
+#include <sys/sa.h>
+#include <sys/sa_impl.h>
+#include <sys/dbuf.h>
+#include <time.h>
+#include <sys/zfs_znode.h>
+#include <sys/zap.h>
+#include <sys/dmu.h>
+#include <sys/nvpair.h>
+#include <umem.h>
+#include "libuzfs_impl.h"
+#include <inttypes.h>
+
+typedef enum {
+	TYPE_FILE,
+	TYPE_DIR,
+	TYPE_SYMLINK,
+	TYPE_SOCK,
+	TYPE_FIFO,
+	TYPE_CHR,
+	TYPE_BLK
+} FileType;
+
+typedef struct {
+	uint64_t ino;
+	uint64_t pino;
+	uint32_t psid;
+	FileType ftype;
+	uint64_t gen;
+	uint32_t nlink;
+	uint32_t perm;
+	uint32_t uid;
+	uint32_t gid;
+	uint64_t size;
+	uint64_t blksize;
+	uint64_t blocks;
+	uint32_t nsid;
+	struct timespec atime;
+	struct timespec mtime;
+	struct timespec ctime;
+	struct timespec btime;
+} attr_t;
+
+typedef enum uzfs_attr {
+	UZFS_INO,
+	UZFS_PINO,
+	UZFS_PSID,
+	UZFS_FTYPE,
+	UZFS_GEN,
+	UZFS_NLINK,
+	UZFS_PERM,
+	UZFS_UID,
+	UZFS_GID,
+	UZFS_SIZE,
+	UZFS_BLKSIZE,
+	UZFS_BLOCKS,
+	UZFS_NSID,
+	UZFS_ATIME,
+	UZFS_MTIME,
+	UZFS_CTIME,
+	UZFS_BTIME,
+	UZFS_DXATTR, // sa index for dir xattr inode
+	UZFS_XATTR,  // sa index for sa xattr (name, value) pairs
+	UZFS_END
+} uzfs_attr_t;
+
+sa_attr_reg_t uzfs_attr_table[UZFS_END+1] = {
+	{"UZFS_INO", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
+	{"UZFS_PINO", sizeof (uint64_t), SA_UINT64_ARRAY, 1},
+	{"UZFS_PSID", sizeof (uint32_t), SA_UINT32_ARRAY, 2},
+	{"UZFS_FTYPE", sizeof (FileType), SA_UINT32_ARRAY, 3},
+	{"UZFS_GEN", sizeof (uint64_t), SA_UINT64_ARRAY, 4},
+	{"UZFS_NLINK", sizeof (uint32_t), SA_UINT32_ARRAY, 5},
+	{"UZFS_PERM", sizeof (uint32_t), SA_UINT32_ARRAY, 6},
+	{"UZFS_UID", sizeof (uint32_t), SA_UINT32_ARRAY, 7},
+	{"UZFS_GID", sizeof (uint32_t), SA_UINT32_ARRAY, 8},
+	{"UZFS_SIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 9},
+	{"UZFS_BLKSIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 10},
+	{"UZFS_BLOCKS", sizeof (uint64_t), SA_UINT64_ARRAY, 11},
+	{"UZFS_NSID", sizeof (uint32_t), SA_UINT32_ARRAY, 12},
+	{"UZFS_ATIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 13},
+	{"UZFS_MTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 14},
+	{"UZFS_CTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 15},
+	{"UZFS_BTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 16},
+	{"UZFS_DXATTR", sizeof (uint64_t), SA_UINT64_ARRAY, 17},
+	{"UZFS_XATTR", 0, SA_UINT8_ARRAY, 0},
+	{NULL, 0, 0, 0}
+};
+
+void
+libuzfs_create_objset_attr(objset_t *os, dmu_tx_t *tx)
+{
+	int err = zap_create_claim(os, MASTER_NODE_OBJ, DMU_OT_MASTER_NODE, 
+								 DMU_OT_NONE, 0, tx);
+	ASSERT(err == 0);
+
+	uint64_t sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
+		    					 DMU_OT_NONE, 0, tx);
+	err = zap_add(os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
+	ASSERT(err == 0);
+}
+
+void
+libuzfs_open_dataset_attr(libuzfs_dataset_handle_t *dhp)
+{
+	uint64_t sa_obj;
+	VERIFY0(zap_lookup(dhp->os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj));
+	sa_setup(dhp->os, sa_obj, uzfs_attr_table, UZFS_END, &dhp->uzfs_attr_table);
+}
+
+// make sure sa_attrs has enough space
+static void
+libuzfs_add_bulk_attr(libuzfs_dataset_handle_t *dhp, sa_bulk_attr_t *sa_attrs,
+					  int *cnt, attr_t *attr)
+{
+	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_INO], NULL, &attr->ino, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PINO], NULL, &attr->pino, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PSID], NULL, &attr->psid, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_FTYPE], NULL, &attr->ftype, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GEN], NULL, &attr->gen, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NLINK], NULL, &attr->nlink, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PERM], NULL, &attr->perm, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_UID], NULL, &attr->uid, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GID], NULL, &attr->gid, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_SIZE], NULL, &attr->size, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLKSIZE], NULL, &attr->blksize, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLOCKS], NULL, &attr->blocks, 8);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NSID], NULL, &attr->nsid, 4);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_ATIME], NULL, &attr->atime, 16);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_MTIME], NULL, &attr->mtime, 16);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_CTIME], NULL, &attr->ctime, 16);
+	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BTIME], NULL, &attr->btime, 16);
+}
+
+static int
+libuzfs_object_attr_init(libuzfs_dataset_handle_t *dhp, sa_handle_t *sa_hdl, dmu_tx_t *tx)
+{
+	sa_bulk_attr_t sa_attrs[20];
+	int cnt = 0;
+	attr_t attr;
+	memset(&attr, 0, sizeof(attr));
+	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, &attr);
+	return sa_replace_all_by_template(sa_hdl, sa_attrs, cnt, tx);
+}
+
+int
+libuzfs_create_inode_with_type(libuzfs_dataset_handle_t *dhp, uint64_t *obj,
+							   boolean_t claiming, libuzfs_inode_type_t type,
+							   uint64_t opid)
+{
+	dmu_tx_t *tx = dmu_tx_create(dhp->os);
+	dmu_tx_hold_sa_create(tx, ZFS_SA_BASE_ATTR_SIZE);
+	int err = dmu_tx_assign(tx, TXG_WAIT);
+	if (err != 0) {
+		goto fail;
+	}
+
+	// create/claim object
+	objset_t *os = dhp->os;
+	int dnodesize = dmu_objset_dnodesize(os);
+	int bonuslen = DN_BONUS_SIZE(dnodesize);
+	if (type == INODE_FILE) {
+		if (claiming) {
+			ASSERT(*obj != 0);
+			err = dmu_object_claim_dnsize(os, *obj, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+											DMU_OT_SA, bonuslen, dnodesize, tx);
+		} else {
+			*obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+	    						   		   DMU_OT_SA, bonuslen, dnodesize, tx);
+		}
+	} else {
+		if (claiming) {
+			ASSERT(*obj != 0);
+			err = zap_create_claim_dnsize(os, *obj, DMU_OT_DIRECTORY_CONTENTS,
+											DMU_OT_SA, bonuslen, dnodesize, tx);
+		} else {
+			*obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS,
+									 DMU_OT_SA, bonuslen, dnodesize, tx);
+		}
+	}
+	if (err != 0) {
+		goto fail;
+	}
+
+	sa_handle_t *sa_hdl;
+	sa_handle_get(os, *obj, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	err = libuzfs_object_attr_init(dhp, sa_hdl, tx);
+	// maybe we shouldn't destroy handle here
+	sa_handle_destroy(sa_hdl);
+	if (err == 0) {
+		if (opid != 0) {
+			dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+		}
+		dmu_tx_commit(tx);
+		return 0;
+	}
+
+fail:
+	dmu_tx_abort(tx);
+	return err;
+}
+
+int
+libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+                     libuzfs_inode_type_t type, uint64_t opid)
+{
+	objset_t *os = dhp->os;
+	sa_handle_t *sa_hdl;
+	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+
+	dmu_tx_t *tx = dmu_tx_create(os);
+	dmu_tx_hold_free(tx, ino, 0, DMU_OBJECT_END);
+	uint64_t xattr_obj = 0;
+	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+	err = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR],
+					&xattr_obj, sizeof(xattr_obj));
+	
+	uint64_t *value_objs = NULL;
+	uint64_t obj_cnt = 0;
+	if (err == 0 && xattr_obj != 0) {
+		dmu_tx_hold_free(tx, xattr_obj, 0, DMU_OBJECT_END);
+		if ((err = zap_count(os, xattr_obj, &obj_cnt)) != 0) {
+			goto out;
+		}
+		if (obj_cnt > 0) {
+			value_objs = (uint64_t *)umem_alloc(obj_cnt * sizeof(uint64_t),
+												UMEM_NOFAIL);
+		}
+		zap_cursor_t zc;
+		zap_attribute_t attr;
+		uint64_t pos = 0;
+		for (zap_cursor_init(&zc, os, xattr_obj); 
+			 zap_cursor_retrieve(&zc, &attr) == 0;
+	    	 zap_cursor_advance(&zc)) {
+			ASSERT(attr.za_integer_length == 8);
+			ASSERT(attr.za_num_integers == 1);
+
+			uint64_t value_obj;
+			VERIFY0(zap_lookup(os, xattr_obj, attr.za_name, 8, 1, &value_obj));
+			value_objs[pos++] = value_obj;
+			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+		}
+	}
+	sa_handle_destroy(sa_hdl);
+
+	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+		goto out;
+	}
+
+	if (xattr_obj != 0) {
+		zap_destroy(os, xattr_obj, tx);
+		for (uint64_t i = 0; i < obj_cnt; ++i) {
+			dmu_object_free(os, value_objs[i], tx);
+		}
+	}
+
+	if (type == INODE_DIR) {
+		err = zap_destroy(os, ino, tx);
+	} else {
+		err = dmu_object_free(os, ino, tx);
+	}
+
+out:
+	if (obj_cnt > 0) {
+		umem_free(value_objs, sizeof(uint64_t) * obj_cnt);
+	}
+
+	if (err == 0) {
+		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+		dmu_tx_commit(tx);
+	} else {
+		dmu_tx_abort(tx);
+	}
+	return err;
+}
+
+int
+libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    				  void *attr, uint64_t size)
+{
+	sa_handle_t *sa_hdl;
+	int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+
+	sa_bulk_attr_t sa_attrs[20];
+	int cnt = 0;
+	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
+	err = sa_bulk_lookup(sa_hdl, sa_attrs, cnt);
+	
+	sa_handle_destroy(sa_hdl);
+	return err;
+}
+
+int
+libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    				  const void *attr, uint64_t size, uint64_t opid)
+{
+
+	sa_handle_t *sa_hdl;
+	objset_t *os = dhp->os;
+	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+	
+	dmu_tx_t *tx = dmu_tx_create(os);
+	// for now, we assume size of attr won't grow larger than bonus buffer;
+	dmu_tx_hold_sa(tx, sa_hdl, B_FALSE);
+	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+		goto fail;
+	}
+
+	sa_bulk_attr_t sa_attrs[20];
+	int cnt = 0;
+	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
+	err = sa_bulk_update(sa_hdl, sa_attrs, cnt, tx);
+	sa_handle_destroy(sa_hdl);
+	if (err == 0) {
+		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+		dmu_tx_commit(tx);
+		return 0;
+	}
+
+fail:
+	dmu_tx_abort(tx);
+	return err;
+}
+
+static int
+get_nvlist_from_handle(const sa_attr_type_t *sa_tbl, nvlist_t **nvl, sa_handle_t *sa_hdl)
+{
+	int xattr_size;
+	int err = sa_size(sa_hdl, sa_tbl[UZFS_XATTR], &xattr_size);
+	if (err != 0) {
+		return err;
+	}
+
+	char *obj = vmem_alloc(xattr_size, KM_SLEEP);
+	err = sa_lookup(sa_hdl, sa_tbl[UZFS_XATTR], obj, xattr_size);
+	if (err != 0) {
+		return err;
+	}
+
+	err = nvlist_unpack(obj, xattr_size, nvl, KM_SLEEP);
+	vmem_free(obj, xattr_size);
+	return err;
+}
+
+static void
+libuzfs_tx_hold_kvattr_set(dmu_tx_t *tx, int err_check_sa_enough, int err_check_sa,
+						   int err_check_dir, uint64_t xattr_obj, uint64_t value_obj,
+						   size_t size, const char *name)
+{
+	if (err_check_sa == 0) {
+		if (err_check_sa_enough != 0) {
+			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+			// first 8 bytes of value obj stores size of value
+			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+		}
+	} else if (err_check_dir == 0) {
+		ASSERT(xattr_obj != DMU_NEW_OBJECT && value_obj != DMU_NEW_OBJECT);
+		if (err_check_sa_enough == 0) {
+			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+		} else {
+			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+		}
+	} else {
+		if (err_check_sa_enough != 0) {
+			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+			// first 8 bytes of value obj stores size of value
+			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+		}
+	}
+}
+
+static int
+libuzfs_kvattr_set_nvlist(nvlist_t *nvl, int err_check_sa, int *err_check_sa_enough,
+						  const char *name, const char *value, size_t value_size, 
+						  size_t *xattr_sa_size)
+{
+	int err = 0;
+	if (value == NULL && err_check_sa == 0) {
+		err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY);
+	} else if (value != NULL) {
+		err = nvlist_add_byte_array(nvl, name, (uchar_t *)value, (uint_t)value_size);
+	}
+	if (err != 0) {
+		return err;
+	}
+	err = nvlist_size(nvl, xattr_sa_size, NV_ENCODE_XDR);
+	if (err != 0) {
+		return err;
+	}
+	if (*xattr_sa_size > DXATTR_MAX_SA_SIZE || *xattr_sa_size > SA_ATTR_MAX_LEN) {
+		*err_check_sa_enough = EFBIG;
+		if ((err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY)) != 0 
+			 && value != NULL) {
+			return err;
+		}
+	}
+	return err;
+}
+
+static int
+libuzfs_save_xattr_dir(sa_handle_t *sa_hdl, sa_attr_type_t *attr_tbl,
+					   uint64_t xattr_obj, uint64_t value_obj, const char *name, 
+					   const char *value, size_t size, dmu_tx_t *tx)
+{
+	int err = 0;
+	objset_t *os = sa_hdl->sa_os;
+	int dnodesize = dmu_objset_dnodesize(os);
+	if (xattr_obj == DMU_NEW_OBJECT) {
+		xattr_obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS, 
+									  DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
+		err = sa_update(sa_hdl, attr_tbl[UZFS_DXATTR], &xattr_obj, 8, tx);
+		if (err != 0) {
+			return err;
+		}
+	}
+	if (value_obj == DMU_NEW_OBJECT) {
+		value_obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+											DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
+	}
+	struct iovec iov[2];
+	iov[0].iov_base = &size;
+	iov[0].iov_len = sizeof(uint64_t);
+	iov[1].iov_base = (void *)value;
+	iov[1].iov_len = size;
+
+	zfs_uio_t uio;
+	zfs_uio_iovec_init(&uio, iov, 2, 0, UIO_USERSPACE, size + sizeof(uint64_t), 0);
+	err = dmu_write_uio(os, value_obj, &uio, size + sizeof(uint64_t), tx);
+	if (err == 0) {
+		err = zap_update(os, xattr_obj, name, 8, 1, &value_obj, tx);
+	}
+
+	return err;
+}
+
+int
+libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    					 const char *name, const char *value,
+						 uint64_t size, int flags, uint64_t opid)
+{
+	// 1. this name is in sa: 
+	//    1.1 sa has enough space for new value, just put in
+	//    1.2 no enough space, delete from sa and put in dir
+	// 2. in dir
+	//    2.1 sa enough space, delete from dir and put in sa
+	//    2.2 not enough, put in dir
+	// 3. neigther
+	//    3.1 sa enough, put in sa
+	//    3.2 not enough, put in dir
+	sa_handle_t	*sa_hdl;
+	objset_t *os = dhp->os;
+	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+
+	nvlist_t *nvl;
+	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+	err = get_nvlist_from_handle(attr_tbl, &nvl, sa_hdl);
+	if (err == ENOENT) {
+		err = nvlist_alloc(&nvl, NV_UNIQUE_NAME, KM_SLEEP);
+	}
+
+	if (err != 0) {
+		goto out;
+	}
+
+	int err_check_sa = nvlist_exists(nvl, name);
+	int err_check_sa_enough = 0;
+	size_t xattr_size = 0;
+	if (size > DXATTR_MAX_ENTRY_SIZE) {
+		err_check_sa_enough = EFBIG;
+	} else {
+		err = libuzfs_kvattr_set_nvlist(nvl, err_check_sa, &err_check_sa_enough, 
+										name, value, size, &xattr_size);
+		if (err != 0) {
+			goto out2;
+		}
+	}
+
+	uint64_t xattr_obj = DMU_NEW_OBJECT;
+	int err_check_dir = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR], 
+								  &xattr_obj, sizeof(xattr_obj));
+	ASSERT(err_check_dir == ENOENT || err_check_dir == 0);
+	uint64_t value_obj = DMU_NEW_OBJECT;
+	if (err_check_sa != 0 && err_check_dir == 0) {
+		err_check_dir = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj);
+		if (err_check_dir != ENOENT && err_check_dir != 0) {
+			err = err_check_dir;
+			goto out2;
+		}
+	}
+
+	// this is remove operation, but we didn't find the name in either sa or dir
+	if (value == NULL && err_check_sa != 0 && err_check_dir != 0) {
+		err = ENOENT;
+		goto out2;
+	}
+
+	dmu_tx_t *tx = dmu_tx_create(os);
+	dmu_tx_hold_sa(tx, sa_hdl, B_TRUE);
+	// hold buffers this tx will change before assign it
+	if (value == NULL) {
+		if (err_check_sa != 0 && err_check_dir == 0) {
+			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+		}
+	} else {
+		libuzfs_tx_hold_kvattr_set(tx, err_check_sa_enough, 
+								   err_check_sa, err_check_dir, 
+								   xattr_obj, value_obj, size, name);
+	}
+	
+	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+		goto out3;
+	}
+
+	// name was deleted/inserted in nvl before, so we just need to save the nvl
+	if (err_check_sa == 0 || (err_check_sa_enough == 0 && value != NULL)) {
+		if (xattr_size > 0) {
+			char *packed_nvl = vmem_alloc(xattr_size, KM_SLEEP);
+			err = nvlist_pack(nvl, &packed_nvl, &xattr_size,
+							  NV_ENCODE_XDR, KM_SLEEP);
+			if (err == 0) {
+				VERIFY0(sa_update(sa_hdl, attr_tbl[UZFS_XATTR],
+								  packed_nvl, xattr_size, tx));
+			}
+			vmem_free(packed_nvl, xattr_size);
+		} else {
+			VERIFY0(sa_remove(sa_hdl, attr_tbl[UZFS_XATTR], tx));
+		}
+	}
+
+	// free the object that saves old value and remove its entry in xattr_obj
+	if ((err_check_sa_enough == 0 || value == NULL) &&
+		 err_check_sa != 0 && err_check_dir == 0) {
+		dmu_object_free(os, value_obj, tx);
+		// should we delete the xattr_obj and its sa entry when xattr_obj is empty?
+		VERIFY0(zap_remove(os, xattr_obj, name, tx));
+	}
+
+	if (value == NULL || err != 0) {
+		goto out3;
+	}
+
+	if (err_check_sa_enough != 0) {
+		err = libuzfs_save_xattr_dir(sa_hdl, attr_tbl, xattr_obj, 
+									 value_obj, name, value, size, tx);
+	}
+
+out3:
+	if (err != 0) {
+		dmu_tx_abort(tx);
+	} else {
+		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+		dmu_tx_commit(tx);
+	}
+out2:
+	nvlist_free(nvl);
+out:
+	sa_handle_destroy(sa_hdl);
+	return err;
+}
+
+static int
+libuzfs_inode_get_kvattr_dir(const sa_attr_type_t *sa_tbl, sa_handle_t *sa_hdl,
+							 const char *name, char *value, size_t size)
+{
+	// get zap object from sa
+	uint64_t xattr_obj;
+	int err = sa_lookup(sa_hdl, sa_tbl[UZFS_DXATTR],
+						&xattr_obj, sizeof(uint64_t));
+	if (err != 0) {
+		return err;
+	}
+
+	objset_t *os = sa_hdl->sa_os;
+	uint64_t value_obj;
+	if((err = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj)) != 0) {
+		return err;
+	}
+
+	// TODO(sundengyu): use one dmu_read
+	uint64_t stored_size;
+	err = dmu_read(os, value_obj, 0, sizeof(uint64_t),
+				   &stored_size, DMU_READ_PREFETCH);
+	if (err == 0 && stored_size > size) {
+		err = ERANGE;
+	} else if (err == 0) {
+		err = dmu_read(os, value_obj, sizeof(uint64_t),
+					   stored_size, value, DMU_READ_PREFETCH);
+	}
+	return err;
+}
+
+static int
+libuzfs_inode_get_kvattr_sa(const sa_attr_type_t *sa_tbl, sa_handle_t *sa_hdl,
+							const char *name, char *value, size_t size)
+{
+	nvlist_t *nvl;
+	int err = get_nvlist_from_handle(sa_tbl, &nvl, sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+
+	uchar_t *nv_value;
+	uint_t nv_size = 0;
+	err = nvlist_lookup_byte_array(nvl, name, &nv_value, &nv_size);
+	if (err == 0 && nv_size <= size) {
+		if (value != NULL) {
+			memcpy(value, nv_value, nv_size);
+		}
+	}
+	nvlist_free(nvl);
+
+	if (nv_size > size) {
+		return ERANGE;
+	}
+	return err;
+}
+
+int
+libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+    					 const char *name, char *value, uint64_t size,
+						 int flags)
+{
+	sa_handle_t	*sa_hdl;
+	int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+	if (err != 0) {
+		return err;
+	}
+
+	err = libuzfs_inode_get_kvattr_sa(dhp->uzfs_attr_table, sa_hdl,
+									  name, value, size);
+	if (err == 0 || err != ENOENT) {
+		goto out;
+	}
+
+	err = libuzfs_inode_get_kvattr_dir(dhp->uzfs_attr_table, sa_hdl,
+									   name, value, size);
+
+out:
+	sa_handle_destroy(sa_hdl);
+	return err;
+}
+
+int
+libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
+							const char *name, uint64_t opid)
+{
+	return libuzfs_inode_set_kvattr(dhp, ino, name, NULL, 0, 0, opid);
+}

--- a/lib/libuzfs/libuzfs_attr.c
+++ b/lib/libuzfs/libuzfs_attr.c
@@ -12,436 +12,435 @@
 #include <inttypes.h>
 
 typedef enum {
-	TYPE_FILE,
-	TYPE_DIR,
-	TYPE_SYMLINK,
-	TYPE_SOCK,
-	TYPE_FIFO,
-	TYPE_CHR,
-	TYPE_BLK
+    TYPE_FILE,
+    TYPE_DIR,
+    TYPE_SYMLINK,
+    TYPE_SOCK,
+    TYPE_FIFO,
+    TYPE_CHR,
+    TYPE_BLK
 } FileType;
 
 typedef struct {
-	uint64_t ino;
-	uint64_t pino;
-	uint32_t psid;
-	FileType ftype;
-	uint64_t gen;
-	uint32_t nlink;
-	uint32_t perm;
-	uint32_t uid;
-	uint32_t gid;
-	uint64_t size;
-	uint64_t blksize;
-	uint64_t blocks;
-	uint32_t nsid;
-	struct timespec atime;
-	struct timespec mtime;
-	struct timespec ctime;
-	struct timespec btime;
+    uint64_t ino;
+    uint64_t pino;
+    uint32_t psid;
+    FileType ftype;
+    uint64_t gen;
+    uint32_t nlink;
+    uint32_t perm;
+    uint32_t uid;
+    uint32_t gid;
+    uint64_t size;
+    uint64_t blksize;
+    uint64_t blocks;
+    uint32_t nsid;
+    struct timespec atime;
+    struct timespec mtime;
+    struct timespec ctime;
+    struct timespec btime;
 } attr_t;
 
 typedef enum uzfs_attr {
-	UZFS_INO,
-	UZFS_PINO,
-	UZFS_PSID,
-	UZFS_FTYPE,
-	UZFS_GEN,
-	UZFS_NLINK,
-	UZFS_PERM,
-	UZFS_UID,
-	UZFS_GID,
-	UZFS_SIZE,
-	UZFS_BLKSIZE,
-	UZFS_BLOCKS,
-	UZFS_NSID,
-	UZFS_ATIME,
-	UZFS_MTIME,
-	UZFS_CTIME,
-	UZFS_BTIME,
-	UZFS_DXATTR, // sa index for dir xattr inode
-	UZFS_XATTR,  // sa index for sa xattr (name, value) pairs
-	UZFS_END
+    UZFS_INO,
+    UZFS_PINO,
+    UZFS_PSID,
+    UZFS_FTYPE,
+    UZFS_GEN,
+    UZFS_NLINK,
+    UZFS_PERM,
+    UZFS_UID,
+    UZFS_GID,
+    UZFS_SIZE,
+    UZFS_BLKSIZE,
+    UZFS_BLOCKS,
+    UZFS_NSID,
+    UZFS_ATIME,
+    UZFS_MTIME,
+    UZFS_CTIME,
+    UZFS_BTIME,
+    UZFS_DXATTR, // sa index for dir xattr inode
+    UZFS_XATTR,  // sa index for sa xattr (name, value) pairs
+    UZFS_END
 } uzfs_attr_t;
 
 sa_attr_reg_t uzfs_attr_table[UZFS_END+1] = {
-	{"UZFS_INO", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
-	{"UZFS_PINO", sizeof (uint64_t), SA_UINT64_ARRAY, 1},
-	{"UZFS_PSID", sizeof (uint32_t), SA_UINT32_ARRAY, 2},
-	{"UZFS_FTYPE", sizeof (FileType), SA_UINT32_ARRAY, 3},
-	{"UZFS_GEN", sizeof (uint64_t), SA_UINT64_ARRAY, 4},
-	{"UZFS_NLINK", sizeof (uint32_t), SA_UINT32_ARRAY, 5},
-	{"UZFS_PERM", sizeof (uint32_t), SA_UINT32_ARRAY, 6},
-	{"UZFS_UID", sizeof (uint32_t), SA_UINT32_ARRAY, 7},
-	{"UZFS_GID", sizeof (uint32_t), SA_UINT32_ARRAY, 8},
-	{"UZFS_SIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 9},
-	{"UZFS_BLKSIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 10},
-	{"UZFS_BLOCKS", sizeof (uint64_t), SA_UINT64_ARRAY, 11},
-	{"UZFS_NSID", sizeof (uint32_t), SA_UINT32_ARRAY, 12},
-	{"UZFS_ATIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 13},
-	{"UZFS_MTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 14},
-	{"UZFS_CTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 15},
-	{"UZFS_BTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 16},
-	{"UZFS_DXATTR", sizeof (uint64_t), SA_UINT64_ARRAY, 17},
-	{"UZFS_XATTR", 0, SA_UINT8_ARRAY, 0},
-	{NULL, 0, 0, 0}
+    {"UZFS_INO", sizeof (uint64_t), SA_UINT64_ARRAY, 0},
+    {"UZFS_PINO", sizeof (uint64_t), SA_UINT64_ARRAY, 1},
+    {"UZFS_PSID", sizeof (uint32_t), SA_UINT32_ARRAY, 2},
+    {"UZFS_FTYPE", sizeof (FileType), SA_UINT32_ARRAY, 3},
+    {"UZFS_GEN", sizeof (uint64_t), SA_UINT64_ARRAY, 4},
+    {"UZFS_NLINK", sizeof (uint32_t), SA_UINT32_ARRAY, 5},
+    {"UZFS_PERM", sizeof (uint32_t), SA_UINT32_ARRAY, 6},
+    {"UZFS_UID", sizeof (uint32_t), SA_UINT32_ARRAY, 7},
+    {"UZFS_GID", sizeof (uint32_t), SA_UINT32_ARRAY, 8},
+    {"UZFS_SIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 9},
+    {"UZFS_BLKSIZE", sizeof (uint64_t), SA_UINT64_ARRAY, 10},
+    {"UZFS_BLOCKS", sizeof (uint64_t), SA_UINT64_ARRAY, 11},
+    {"UZFS_NSID", sizeof (uint32_t), SA_UINT32_ARRAY, 12},
+    {"UZFS_ATIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 13},
+    {"UZFS_MTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 14},
+    {"UZFS_CTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 15},
+    {"UZFS_BTIME", sizeof (uint64_t) * 2, SA_UINT64_ARRAY, 16},
+    {"UZFS_DXATTR", sizeof (uint64_t), SA_UINT64_ARRAY, 17},
+    {"UZFS_XATTR", 0, SA_UINT8_ARRAY, 0},
+    {NULL, 0, 0, 0}
 };
 
 void
 libuzfs_create_objset_attr(objset_t *os, dmu_tx_t *tx)
 {
-	int err = zap_create_claim(os, MASTER_NODE_OBJ, DMU_OT_MASTER_NODE, 
-								 DMU_OT_NONE, 0, tx);
-	ASSERT(err == 0);
+    int err = zap_create_claim(os, MASTER_NODE_OBJ, DMU_OT_MASTER_NODE, 
+                               DMU_OT_NONE, 0, tx);
+    ASSERT(err == 0);
 
-	uint64_t sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
-		    					 DMU_OT_NONE, 0, tx);
-	err = zap_add(os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
-	ASSERT(err == 0);
+    uint64_t sa_obj = zap_create(os, DMU_OT_SA_MASTER_NODE,
+                                 DMU_OT_NONE, 0, tx);
+    err = zap_add(os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj, tx);
+    ASSERT(err == 0);
 }
 
 void
 libuzfs_open_dataset_attr(libuzfs_dataset_handle_t *dhp)
 {
-	uint64_t sa_obj;
-	VERIFY0(zap_lookup(dhp->os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj));
-	sa_setup(dhp->os, sa_obj, uzfs_attr_table, UZFS_END, &dhp->uzfs_attr_table);
+    uint64_t sa_obj;
+    VERIFY0(zap_lookup(dhp->os, MASTER_NODE_OBJ, ZFS_SA_ATTRS, 8, 1, &sa_obj));
+    sa_setup(dhp->os, sa_obj, uzfs_attr_table, UZFS_END, &dhp->uzfs_attr_table);
 }
 
 // make sure sa_attrs has enough space
 static void
 libuzfs_add_bulk_attr(libuzfs_dataset_handle_t *dhp, sa_bulk_attr_t *sa_attrs,
-					  int *cnt, attr_t *attr)
+                      int *cnt, attr_t *attr)
 {
-	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_INO], NULL, &attr->ino, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PINO], NULL, &attr->pino, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PSID], NULL, &attr->psid, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_FTYPE], NULL, &attr->ftype, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GEN], NULL, &attr->gen, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NLINK], NULL, &attr->nlink, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PERM], NULL, &attr->perm, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_UID], NULL, &attr->uid, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GID], NULL, &attr->gid, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_SIZE], NULL, &attr->size, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLKSIZE], NULL, &attr->blksize, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLOCKS], NULL, &attr->blocks, 8);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NSID], NULL, &attr->nsid, 4);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_ATIME], NULL, &attr->atime, 16);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_MTIME], NULL, &attr->mtime, 16);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_CTIME], NULL, &attr->ctime, 16);
-	SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BTIME], NULL, &attr->btime, 16);
+    sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_INO], NULL, &attr->ino, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PINO], NULL, &attr->pino, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PSID], NULL, &attr->psid, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_FTYPE], NULL, &attr->ftype, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GEN], NULL, &attr->gen, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NLINK], NULL, &attr->nlink, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_PERM], NULL, &attr->perm, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_UID], NULL, &attr->uid, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_GID], NULL, &attr->gid, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_SIZE], NULL, &attr->size, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLKSIZE], NULL, &attr->blksize, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BLOCKS], NULL, &attr->blocks, 8);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_NSID], NULL, &attr->nsid, 4);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_ATIME], NULL, &attr->atime, 16);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_MTIME], NULL, &attr->mtime, 16);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_CTIME], NULL, &attr->ctime, 16);
+    SA_ADD_BULK_ATTR(sa_attrs, *cnt, attr_tbl[UZFS_BTIME], NULL, &attr->btime, 16);
 }
 
 static int
 libuzfs_object_attr_init(libuzfs_dataset_handle_t *dhp, sa_handle_t *sa_hdl, dmu_tx_t *tx)
 {
-	sa_bulk_attr_t sa_attrs[20];
-	int cnt = 0;
-	attr_t attr;
-	memset(&attr, 0, sizeof(attr));
-	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, &attr);
-	return sa_replace_all_by_template(sa_hdl, sa_attrs, cnt, tx);
+    sa_bulk_attr_t sa_attrs[20];
+    int cnt = 0;
+    attr_t attr;
+    memset(&attr, 0, sizeof(attr));
+    libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, &attr);
+    return sa_replace_all_by_template(sa_hdl, sa_attrs, cnt, tx);
 }
 
 int
 libuzfs_create_inode_with_type(libuzfs_dataset_handle_t *dhp, uint64_t *obj,
-							   boolean_t claiming, libuzfs_inode_type_t type,
-							   uint64_t opid)
+                               boolean_t claiming, libuzfs_inode_type_t type,
+                               uint64_t opid)
 {
-	dmu_tx_t *tx = dmu_tx_create(dhp->os);
-	dmu_tx_hold_sa_create(tx, ZFS_SA_BASE_ATTR_SIZE);
-	int err = dmu_tx_assign(tx, TXG_WAIT);
-	if (err != 0) {
-		goto fail;
-	}
+    dmu_tx_t *tx = dmu_tx_create(dhp->os);
+    dmu_tx_hold_sa_create(tx, ZFS_SA_BASE_ATTR_SIZE);
+    int err = dmu_tx_assign(tx, TXG_WAIT);
+    if (err != 0) {
+        goto fail;
+    }
 
-	// create/claim object
-	objset_t *os = dhp->os;
-	int dnodesize = dmu_objset_dnodesize(os);
-	int bonuslen = DN_BONUS_SIZE(dnodesize);
-	if (type == INODE_FILE) {
-		if (claiming) {
-			ASSERT(*obj != 0);
-			err = dmu_object_claim_dnsize(os, *obj, DMU_OT_PLAIN_FILE_CONTENTS, 0,
-											DMU_OT_SA, bonuslen, dnodesize, tx);
-		} else {
-			*obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
-	    						   		   DMU_OT_SA, bonuslen, dnodesize, tx);
-		}
-	} else {
-		if (claiming) {
-			ASSERT(*obj != 0);
-			err = zap_create_claim_dnsize(os, *obj, DMU_OT_DIRECTORY_CONTENTS,
-											DMU_OT_SA, bonuslen, dnodesize, tx);
-		} else {
-			*obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS,
-									 DMU_OT_SA, bonuslen, dnodesize, tx);
-		}
-	}
-	if (err != 0) {
-		goto fail;
-	}
+    // create/claim object
+    objset_t *os = dhp->os;
+    int dnodesize = dmu_objset_dnodesize(os);
+    int bonuslen = DN_BONUS_SIZE(dnodesize);
+    if (type == INODE_FILE) {
+        if (claiming) {
+            ASSERT(*obj != 0);
+            err = dmu_object_claim_dnsize(os, *obj, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+                                          DMU_OT_SA, bonuslen, dnodesize, tx);
+        } else {
+            *obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+                                           DMU_OT_SA, bonuslen, dnodesize, tx);
+        }
+    } else {
+        if (claiming) {
+            ASSERT(*obj != 0);
+            err = zap_create_claim_dnsize(os, *obj, DMU_OT_DIRECTORY_CONTENTS,
+                                          DMU_OT_SA, bonuslen, dnodesize, tx);
+        } else {
+            *obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS,
+                                     DMU_OT_SA, bonuslen, dnodesize, tx);
+        }
+    }
+    if (err != 0) {
+        goto fail;
+    }
 
-	sa_handle_t *sa_hdl;
-	sa_handle_get(os, *obj, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	err = libuzfs_object_attr_init(dhp, sa_hdl, tx);
-	// maybe we shouldn't destroy handle here
-	sa_handle_destroy(sa_hdl);
-	if (err == 0) {
-		if (opid != 0) {
-			dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-		}
-		dmu_tx_commit(tx);
-		return 0;
-	}
+    sa_handle_t *sa_hdl;
+    sa_handle_get(os, *obj, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    err = libuzfs_object_attr_init(dhp, sa_hdl, tx);
+    // maybe we shouldn't destroy handle here
+    sa_handle_destroy(sa_hdl);
+    if (err == 0) {
+        if (opid != 0) {
+            dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+        }
+        dmu_tx_commit(tx);
+        return 0;
+    }
 
 fail:
-	dmu_tx_abort(tx);
-	return err;
+    dmu_tx_abort(tx);
+    return err;
 }
 
 int
 libuzfs_inode_delete(libuzfs_dataset_handle_t *dhp, uint64_t ino,
                      libuzfs_inode_type_t type, uint64_t opid)
 {
-	objset_t *os = dhp->os;
-	sa_handle_t *sa_hdl;
-	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	if (err != 0) {
-		return err;
-	}
+    objset_t *os = dhp->os;
+    sa_handle_t *sa_hdl;
+    int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	dmu_tx_t *tx = dmu_tx_create(os);
-	dmu_tx_hold_free(tx, ino, 0, DMU_OBJECT_END);
-	uint64_t xattr_obj = 0;
-	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
-	err = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR],
-					&xattr_obj, sizeof(xattr_obj));
-	
-	uint64_t *value_objs = NULL;
-	uint64_t obj_cnt = 0;
-	if (err == 0 && xattr_obj != 0) {
-		dmu_tx_hold_free(tx, xattr_obj, 0, DMU_OBJECT_END);
-		if ((err = zap_count(os, xattr_obj, &obj_cnt)) != 0) {
-			goto out;
-		}
-		if (obj_cnt > 0) {
-			value_objs = (uint64_t *)umem_alloc(obj_cnt * sizeof(uint64_t),
-												UMEM_NOFAIL);
-		}
-		zap_cursor_t zc;
-		zap_attribute_t attr;
-		uint64_t pos = 0;
-		for (zap_cursor_init(&zc, os, xattr_obj); 
-			 zap_cursor_retrieve(&zc, &attr) == 0;
-	    	 zap_cursor_advance(&zc)) {
-			ASSERT(attr.za_integer_length == 8);
-			ASSERT(attr.za_num_integers == 1);
+    dmu_tx_t *tx = dmu_tx_create(os);
+    dmu_tx_hold_free(tx, ino, 0, DMU_OBJECT_END);
+    uint64_t xattr_obj = 0;
+    sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+    err = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR],
+                    &xattr_obj, sizeof(xattr_obj));
 
-			uint64_t value_obj;
-			VERIFY0(zap_lookup(os, xattr_obj, attr.za_name, 8, 1, &value_obj));
-			value_objs[pos++] = value_obj;
-			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
-		}
-	}
-	sa_handle_destroy(sa_hdl);
+    uint64_t *value_objs = NULL;
+    uint64_t obj_cnt = 0;
+    if (err == 0 && xattr_obj != 0) {
+        dmu_tx_hold_free(tx, xattr_obj, 0, DMU_OBJECT_END);
+        if ((err = zap_count(os, xattr_obj, &obj_cnt)) != 0) {
+            goto out;
+        }
+        if (obj_cnt > 0) {
+            value_objs = (uint64_t *)umem_alloc(obj_cnt * sizeof(uint64_t),
+                                                UMEM_NOFAIL);
+        }
+        zap_cursor_t zc;
+        zap_attribute_t attr;
+        uint64_t pos = 0;
+        for (zap_cursor_init(&zc, os, xattr_obj); 
+             zap_cursor_retrieve(&zc, &attr) == 0;
+             zap_cursor_advance(&zc)) {
+            ASSERT(attr.za_integer_length == 8);
+            ASSERT(attr.za_num_integers == 1);
 
-	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
-		goto out;
-	}
+            uint64_t value_obj;
+            VERIFY0(zap_lookup(os, xattr_obj, attr.za_name, 8, 1, &value_obj));
+            value_objs[pos++] = value_obj;
+            dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+        }
+    }
+    sa_handle_destroy(sa_hdl);
 
-	if (xattr_obj != 0) {
-		zap_destroy(os, xattr_obj, tx);
-		for (uint64_t i = 0; i < obj_cnt; ++i) {
-			dmu_object_free(os, value_objs[i], tx);
-		}
-	}
+    if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+        goto out;
+    }
 
-	if (type == INODE_DIR) {
-		err = zap_destroy(os, ino, tx);
-	} else {
-		err = dmu_object_free(os, ino, tx);
-	}
+    if (xattr_obj != 0) {
+        zap_destroy(os, xattr_obj, tx);
+        for (uint64_t i = 0; i < obj_cnt; ++i) {
+            dmu_object_free(os, value_objs[i], tx);
+        }
+    }
+
+    if (type == INODE_DIR) {
+        err = zap_destroy(os, ino, tx);
+    } else {
+        err = dmu_object_free(os, ino, tx);
+    }
 
 out:
-	if (obj_cnt > 0) {
-		umem_free(value_objs, sizeof(uint64_t) * obj_cnt);
-	}
+    if (obj_cnt > 0) {
+        umem_free(value_objs, sizeof(uint64_t) * obj_cnt);
+    }
 
-	if (err == 0) {
-		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-		dmu_tx_commit(tx);
-	} else {
-		dmu_tx_abort(tx);
-	}
-	return err;
+    if (err == 0) {
+        dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+        dmu_tx_commit(tx);
+    } else {
+        dmu_tx_abort(tx);
+    }
+    return err;
 }
 
 int
 libuzfs_inode_getattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    				  void *attr, uint64_t size)
+                      void *attr, uint64_t size)
 {
-	sa_handle_t *sa_hdl;
-	int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	if (err != 0) {
-		return err;
-	}
+    sa_handle_t *sa_hdl;
+    int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	sa_bulk_attr_t sa_attrs[20];
-	int cnt = 0;
-	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
-	err = sa_bulk_lookup(sa_hdl, sa_attrs, cnt);
-	
-	sa_handle_destroy(sa_hdl);
-	return err;
+    sa_bulk_attr_t sa_attrs[20];
+    int cnt = 0;
+    libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
+    err = sa_bulk_lookup(sa_hdl, sa_attrs, cnt);
+
+    sa_handle_destroy(sa_hdl);
+    return err;
 }
 
 int
 libuzfs_inode_setattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    				  const void *attr, uint64_t size, uint64_t opid)
+                      const void *attr, uint64_t size, uint64_t opid)
 {
+    sa_handle_t *sa_hdl;
+    objset_t *os = dhp->os;
+    int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	sa_handle_t *sa_hdl;
-	objset_t *os = dhp->os;
-	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	if (err != 0) {
-		return err;
-	}
-	
-	dmu_tx_t *tx = dmu_tx_create(os);
-	// for now, we assume size of attr won't grow larger than bonus buffer;
-	dmu_tx_hold_sa(tx, sa_hdl, B_FALSE);
-	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
-		goto fail;
-	}
+    dmu_tx_t *tx = dmu_tx_create(os);
+    // for now, we assume size of attr won't grow larger than bonus buffer;
+    dmu_tx_hold_sa(tx, sa_hdl, B_FALSE);
+    if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+        goto fail;
+    }
 
-	sa_bulk_attr_t sa_attrs[20];
-	int cnt = 0;
-	libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
-	err = sa_bulk_update(sa_hdl, sa_attrs, cnt, tx);
-	sa_handle_destroy(sa_hdl);
-	if (err == 0) {
-		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-		dmu_tx_commit(tx);
-		return 0;
-	}
+    sa_bulk_attr_t sa_attrs[20];
+    int cnt = 0;
+    libuzfs_add_bulk_attr(dhp, sa_attrs, &cnt, (attr_t *)attr);
+    err = sa_bulk_update(sa_hdl, sa_attrs, cnt, tx);
+    sa_handle_destroy(sa_hdl);
+    if (err == 0) {
+        dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+        dmu_tx_commit(tx);
+        return 0;
+    }
 
 fail:
-	dmu_tx_abort(tx);
-	return err;
+    dmu_tx_abort(tx);
+    return err;
 }
 
 static int
 get_nvlist_from_handle(const sa_attr_type_t *sa_tbl, nvlist_t **nvl, sa_handle_t *sa_hdl)
 {
-	int xattr_size;
-	int err = sa_size(sa_hdl, sa_tbl[UZFS_XATTR], &xattr_size);
-	if (err != 0) {
-		return err;
-	}
+    int xattr_size;
+    int err = sa_size(sa_hdl, sa_tbl[UZFS_XATTR], &xattr_size);
+    if (err != 0) {
+        return err;
+    }
 
-	char *obj = vmem_alloc(xattr_size, KM_SLEEP);
-	err = sa_lookup(sa_hdl, sa_tbl[UZFS_XATTR], obj, xattr_size);
-	if (err != 0) {
-		return err;
-	}
+    char *obj = vmem_alloc(xattr_size, KM_SLEEP);
+    err = sa_lookup(sa_hdl, sa_tbl[UZFS_XATTR], obj, xattr_size);
+    if (err != 0) {
+        return err;
+    }
 
-	err = nvlist_unpack(obj, xattr_size, nvl, KM_SLEEP);
-	vmem_free(obj, xattr_size);
-	return err;
+    err = nvlist_unpack(obj, xattr_size, nvl, KM_SLEEP);
+    vmem_free(obj, xattr_size);
+    return err;
 }
 
 static void
 libuzfs_tx_hold_kvattr_set(dmu_tx_t *tx, int err_check_sa_enough, int err_check_sa,
-						   int err_check_dir, uint64_t xattr_obj, uint64_t value_obj,
-						   size_t size, const char *name)
+                           int err_check_dir, uint64_t xattr_obj, uint64_t value_obj,
+                           size_t size, const char *name)
 {
-	if (err_check_sa == 0) {
-		if (err_check_sa_enough != 0) {
-			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
-			// first 8 bytes of value obj stores size of value
-			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
-		}
-	} else if (err_check_dir == 0) {
-		ASSERT(xattr_obj != DMU_NEW_OBJECT && value_obj != DMU_NEW_OBJECT);
-		if (err_check_sa_enough == 0) {
-			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
-			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
-		} else {
-			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
-		}
-	} else {
-		if (err_check_sa_enough != 0) {
-			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
-			// first 8 bytes of value obj stores size of value
-			dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
-		}
-	}
+    if (err_check_sa == 0) {
+        if (err_check_sa_enough != 0) {
+            dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+            // first 8 bytes of value obj stores size of value
+            dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+        }
+    } else if (err_check_dir == 0) {
+        ASSERT(xattr_obj != DMU_NEW_OBJECT && value_obj != DMU_NEW_OBJECT);
+        if (err_check_sa_enough == 0) {
+            dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+            dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+        } else {
+            dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+        }
+    } else {
+        if (err_check_sa_enough != 0) {
+            dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+            // first 8 bytes of value obj stores size of value
+            dmu_tx_hold_write(tx, value_obj, 0, size + sizeof(uint64_t));
+        }
+    }
 }
 
 static int
 libuzfs_kvattr_set_nvlist(nvlist_t *nvl, int err_check_sa, int *err_check_sa_enough,
-						  const char *name, const char *value, size_t value_size, 
-						  size_t *xattr_sa_size)
+                          const char *name, const char *value, size_t value_size, 
+                          size_t *xattr_sa_size)
 {
-	int err = 0;
-	if (value == NULL && err_check_sa == 0) {
-		err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY);
-	} else if (value != NULL) {
-		err = nvlist_add_byte_array(nvl, name, (uchar_t *)value, (uint_t)value_size);
-	}
-	if (err != 0) {
-		return err;
-	}
-	err = nvlist_size(nvl, xattr_sa_size, NV_ENCODE_XDR);
-	if (err != 0) {
-		return err;
-	}
-	if (*xattr_sa_size > DXATTR_MAX_SA_SIZE || *xattr_sa_size > SA_ATTR_MAX_LEN) {
-		*err_check_sa_enough = EFBIG;
-		if ((err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY)) != 0 
-			 && value != NULL) {
-			return err;
-		}
-	}
-	return err;
+    int err = 0;
+    if (value == NULL && err_check_sa == 0) {
+        err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY);
+    } else if (value != NULL) {
+        err = nvlist_add_byte_array(nvl, name, (uchar_t *)value, (uint_t)value_size);
+    }
+    if (err != 0) {
+        return err;
+    }
+    err = nvlist_size(nvl, xattr_sa_size, NV_ENCODE_XDR);
+    if (err != 0) {
+        return err;
+    }
+    if (*xattr_sa_size > DXATTR_MAX_SA_SIZE || *xattr_sa_size > SA_ATTR_MAX_LEN) {
+        *err_check_sa_enough = EFBIG;
+        if ((err = nvlist_remove(nvl, name, DATA_TYPE_BYTE_ARRAY)) != 0 
+             && value != NULL) {
+            return err;
+        }
+    }
+    return err;
 }
 
 static int
 libuzfs_save_xattr_dir(sa_handle_t *sa_hdl, sa_attr_type_t *attr_tbl,
-					   uint64_t xattr_obj, uint64_t value_obj, const char *name, 
-					   const char *value, size_t size, dmu_tx_t *tx)
+                       uint64_t xattr_obj, uint64_t value_obj, const char *name, 
+                       const char *value, size_t size, dmu_tx_t *tx)
 {
-	int err = 0;
-	objset_t *os = sa_hdl->sa_os;
-	int dnodesize = dmu_objset_dnodesize(os);
-	if (xattr_obj == DMU_NEW_OBJECT) {
-		xattr_obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS, 
-									  DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
-		err = sa_update(sa_hdl, attr_tbl[UZFS_DXATTR], &xattr_obj, 8, tx);
-		if (err != 0) {
-			return err;
-		}
-	}
-	if (value_obj == DMU_NEW_OBJECT) {
-		value_obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
-											DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
-	}
-	struct iovec iov[2];
-	iov[0].iov_base = &size;
-	iov[0].iov_len = sizeof(uint64_t);
-	iov[1].iov_base = (void *)value;
-	iov[1].iov_len = size;
+    int err = 0;
+    objset_t *os = sa_hdl->sa_os;
+    int dnodesize = dmu_objset_dnodesize(os);
+    if (xattr_obj == DMU_NEW_OBJECT) {
+        xattr_obj = zap_create_dnsize(os, DMU_OT_DIRECTORY_CONTENTS, 
+                                      DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
+        err = sa_update(sa_hdl, attr_tbl[UZFS_DXATTR], &xattr_obj, 8, tx);
+        if (err != 0) {
+            return err;
+        }
+    }
+    if (value_obj == DMU_NEW_OBJECT) {
+        value_obj = dmu_object_alloc_dnsize(os, DMU_OT_PLAIN_FILE_CONTENTS, 0,
+                                            DMU_OT_PLAIN_OTHER, 0, dnodesize, tx);
+    }
+    struct iovec iov[2];
+    iov[0].iov_base = &size;
+    iov[0].iov_len = sizeof(uint64_t);
+    iov[1].iov_base = (void *)value;
+    iov[1].iov_len = size;
 
-	zfs_uio_t uio;
-	zfs_uio_iovec_init(&uio, iov, 2, 0, UIO_USERSPACE, size + sizeof(uint64_t), 0);
-	err = dmu_write_uio(os, value_obj, &uio, size + sizeof(uint64_t), tx);
-	if (err == 0) {
-		err = zap_update(os, xattr_obj, name, 8, 1, &value_obj, tx);
-	}
+    zfs_uio_t uio;
+    zfs_uio_iovec_init(&uio, iov, 2, 0, UIO_USERSPACE, size + sizeof(uint64_t), 0);
+    err = dmu_write_uio(os, value_obj, &uio, size + sizeof(uint64_t), tx);
+    if (err == 0) {
+        err = zap_update(os, xattr_obj, name, 8, 1, &value_obj, tx);
+    }
 
-	return err;
+    return err;
 }
 
 int
@@ -449,215 +448,215 @@ libuzfs_inode_set_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
     					 const char *name, const char *value,
 						 uint64_t size, int flags, uint64_t opid)
 {
-	// 1. this name is in sa: 
-	//    1.1 sa has enough space for new value, just put in
-	//    1.2 no enough space, delete from sa and put in dir
-	// 2. in dir
-	//    2.1 sa enough space, delete from dir and put in sa
-	//    2.2 not enough, put in dir
-	// 3. neigther
-	//    3.1 sa enough, put in sa
-	//    3.2 not enough, put in dir
-	sa_handle_t	*sa_hdl;
-	objset_t *os = dhp->os;
-	int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	if (err != 0) {
-		return err;
-	}
+    // 1. this name is in sa: 
+    //    1.1 sa has enough space for new value, just put in
+    //    1.2 no enough space, delete from sa and put in dir
+    // 2. in dir
+    //    2.1 sa enough space, delete from dir and put in sa
+    //    2.2 not enough, put in dir
+    // 3. neigther
+    //    3.1 sa enough, put in sa
+    //    3.2 not enough, put in dir
+    sa_handle_t	*sa_hdl;
+    objset_t *os = dhp->os;
+    int err = sa_handle_get(os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	nvlist_t *nvl;
-	sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
-	err = get_nvlist_from_handle(attr_tbl, &nvl, sa_hdl);
-	if (err == ENOENT) {
-		err = nvlist_alloc(&nvl, NV_UNIQUE_NAME, KM_SLEEP);
-	}
+    nvlist_t *nvl;
+    sa_attr_type_t *attr_tbl = dhp->uzfs_attr_table;
+    err = get_nvlist_from_handle(attr_tbl, &nvl, sa_hdl);
+    if (err == ENOENT) {
+        err = nvlist_alloc(&nvl, NV_UNIQUE_NAME, KM_SLEEP);
+    }
 
-	if (err != 0) {
-		goto out;
-	}
+    if (err != 0) {
+        goto out;
+    }
 
-	int err_check_sa = nvlist_exists(nvl, name);
-	int err_check_sa_enough = 0;
-	size_t xattr_size = 0;
-	if (size > DXATTR_MAX_ENTRY_SIZE) {
-		err_check_sa_enough = EFBIG;
-	} else {
-		err = libuzfs_kvattr_set_nvlist(nvl, err_check_sa, &err_check_sa_enough, 
-										name, value, size, &xattr_size);
-		if (err != 0) {
-			goto out2;
-		}
-	}
+    int err_check_sa = nvlist_exists(nvl, name);
+    int err_check_sa_enough = 0;
+    size_t xattr_size = 0;
+    if (size > DXATTR_MAX_ENTRY_SIZE) {
+        err_check_sa_enough = EFBIG;
+    } else {
+        err = libuzfs_kvattr_set_nvlist(nvl, err_check_sa, &err_check_sa_enough, 
+                                        name, value, size, &xattr_size);
+        if (err != 0) {
+            goto out2;
+        }
+    }
 
-	uint64_t xattr_obj = DMU_NEW_OBJECT;
-	int err_check_dir = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR], 
-								  &xattr_obj, sizeof(xattr_obj));
-	ASSERT(err_check_dir == ENOENT || err_check_dir == 0);
-	uint64_t value_obj = DMU_NEW_OBJECT;
-	if (err_check_sa != 0 && err_check_dir == 0) {
-		err_check_dir = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj);
-		if (err_check_dir != ENOENT && err_check_dir != 0) {
-			err = err_check_dir;
-			goto out2;
-		}
-	}
+    uint64_t xattr_obj = DMU_NEW_OBJECT;
+    int err_check_dir = sa_lookup(sa_hdl, attr_tbl[UZFS_DXATTR], 
+                                  &xattr_obj, sizeof(xattr_obj));
+    ASSERT(err_check_dir == ENOENT || err_check_dir == 0);
+    uint64_t value_obj = DMU_NEW_OBJECT;
+    if (err_check_sa != 0 && err_check_dir == 0) {
+        err_check_dir = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj);
+        if (err_check_dir != ENOENT && err_check_dir != 0) {
+            err = err_check_dir;
+            goto out2;
+        }
+    }
 
-	// this is remove operation, but we didn't find the name in either sa or dir
-	if (value == NULL && err_check_sa != 0 && err_check_dir != 0) {
-		err = ENOENT;
-		goto out2;
-	}
+    // this is remove operation, but we didn't find the name in either sa or dir
+    if (value == NULL && err_check_sa != 0 && err_check_dir != 0) {
+        err = ENOENT;
+        goto out2;
+    }
 
-	dmu_tx_t *tx = dmu_tx_create(os);
-	dmu_tx_hold_sa(tx, sa_hdl, B_TRUE);
-	// hold buffers this tx will change before assign it
-	if (value == NULL) {
-		if (err_check_sa != 0 && err_check_dir == 0) {
-			dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
-			dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
-		}
-	} else {
-		libuzfs_tx_hold_kvattr_set(tx, err_check_sa_enough, 
-								   err_check_sa, err_check_dir, 
-								   xattr_obj, value_obj, size, name);
-	}
-	
-	if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
-		goto out3;
-	}
+    dmu_tx_t *tx = dmu_tx_create(os);
+    dmu_tx_hold_sa(tx, sa_hdl, B_TRUE);
+    // hold buffers this tx will change before assign it
+    if (value == NULL) {
+        if (err_check_sa != 0 && err_check_dir == 0) {
+            dmu_tx_hold_zap(tx, xattr_obj, B_TRUE, name);
+            dmu_tx_hold_free(tx, value_obj, 0, DMU_OBJECT_END);
+        }
+    } else {
+        libuzfs_tx_hold_kvattr_set(tx, err_check_sa_enough, 
+                                   err_check_sa, err_check_dir, 
+                                   xattr_obj, value_obj, size, name);
+    }
 
-	// name was deleted/inserted in nvl before, so we just need to save the nvl
-	if (err_check_sa == 0 || (err_check_sa_enough == 0 && value != NULL)) {
-		if (xattr_size > 0) {
-			char *packed_nvl = vmem_alloc(xattr_size, KM_SLEEP);
-			err = nvlist_pack(nvl, &packed_nvl, &xattr_size,
-							  NV_ENCODE_XDR, KM_SLEEP);
-			if (err == 0) {
-				VERIFY0(sa_update(sa_hdl, attr_tbl[UZFS_XATTR],
-								  packed_nvl, xattr_size, tx));
-			}
-			vmem_free(packed_nvl, xattr_size);
-		} else {
-			VERIFY0(sa_remove(sa_hdl, attr_tbl[UZFS_XATTR], tx));
-		}
-	}
+    if ((err = dmu_tx_assign(tx, TXG_WAIT)) != 0) {
+        goto out3;
+    }
 
-	// free the object that saves old value and remove its entry in xattr_obj
-	if ((err_check_sa_enough == 0 || value == NULL) &&
-		 err_check_sa != 0 && err_check_dir == 0) {
-		dmu_object_free(os, value_obj, tx);
-		// should we delete the xattr_obj and its sa entry when xattr_obj is empty?
-		VERIFY0(zap_remove(os, xattr_obj, name, tx));
-	}
+    // name was deleted/inserted in nvl before, so we just need to save the nvl
+    if (err_check_sa == 0 || (err_check_sa_enough == 0 && value != NULL)) {
+        if (xattr_size > 0) {
+            char *packed_nvl = vmem_alloc(xattr_size, KM_SLEEP);
+            err = nvlist_pack(nvl, &packed_nvl, &xattr_size,
+                              NV_ENCODE_XDR, KM_SLEEP);
+            if (err == 0) {
+                VERIFY0(sa_update(sa_hdl, attr_tbl[UZFS_XATTR],
+                                  packed_nvl, xattr_size, tx));
+            }
+            vmem_free(packed_nvl, xattr_size);
+        } else {
+            VERIFY0(sa_remove(sa_hdl, attr_tbl[UZFS_XATTR], tx));
+        }
+    }
 
-	if (value == NULL || err != 0) {
-		goto out3;
-	}
+    // free the object that saves old value and remove its entry in xattr_obj
+    if ((err_check_sa_enough == 0 || value == NULL) &&
+        err_check_sa != 0 && err_check_dir == 0) {
+        dmu_object_free(os, value_obj, tx);
+        // should we delete the xattr_obj and its sa entry when xattr_obj is empty?
+        VERIFY0(zap_remove(os, xattr_obj, name, tx));
+    }
 
-	if (err_check_sa_enough != 0) {
-		err = libuzfs_save_xattr_dir(sa_hdl, attr_tbl, xattr_obj, 
-									 value_obj, name, value, size, tx);
-	}
+    if (value == NULL || err != 0) {
+        goto out3;
+    }
+
+    if (err_check_sa_enough != 0) {
+        err = libuzfs_save_xattr_dir(sa_hdl, attr_tbl, xattr_obj, 
+                                     value_obj, name, value, size, tx);
+    }
 
 out3:
-	if (err != 0) {
-		dmu_tx_abort(tx);
-	} else {
-		dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
-		dmu_tx_commit(tx);
-	}
+    if (err != 0) {
+        dmu_tx_abort(tx);
+    } else {
+        dsl_dataset_update_max_opid(dmu_objset_ds(os), opid, tx);
+        dmu_tx_commit(tx);
+    }
 out2:
-	nvlist_free(nvl);
+    nvlist_free(nvl);
 out:
-	sa_handle_destroy(sa_hdl);
-	return err;
+    sa_handle_destroy(sa_hdl);
+    return err;
 }
 
 static int
 libuzfs_inode_get_kvattr_dir(const sa_attr_type_t *sa_tbl, sa_handle_t *sa_hdl,
-							 const char *name, char *value, size_t size)
+                             const char *name, char *value, size_t size)
 {
-	// get zap object from sa
-	uint64_t xattr_obj;
-	int err = sa_lookup(sa_hdl, sa_tbl[UZFS_DXATTR],
-						&xattr_obj, sizeof(uint64_t));
-	if (err != 0) {
-		return err;
-	}
+    // get zap object from sa
+    uint64_t xattr_obj;
+    int err = sa_lookup(sa_hdl, sa_tbl[UZFS_DXATTR],
+                        &xattr_obj, sizeof(uint64_t));
+    if (err != 0) {
+        return err;
+    }
 
-	objset_t *os = sa_hdl->sa_os;
-	uint64_t value_obj;
-	if((err = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj)) != 0) {
-		return err;
-	}
+    objset_t *os = sa_hdl->sa_os;
+    uint64_t value_obj;
+    if((err = zap_lookup(os, xattr_obj, name, 8, 1, &value_obj)) != 0) {
+        return err;
+    }
 
-	// TODO(sundengyu): use one dmu_read
-	uint64_t stored_size;
-	err = dmu_read(os, value_obj, 0, sizeof(uint64_t),
-				   &stored_size, DMU_READ_PREFETCH);
-	if (err == 0 && stored_size > size) {
-		err = ERANGE;
-	} else if (err == 0) {
-		err = dmu_read(os, value_obj, sizeof(uint64_t),
-					   stored_size, value, DMU_READ_PREFETCH);
-	}
-	return err;
+    // TODO(sundengyu): use one dmu_read
+    uint64_t stored_size;
+    err = dmu_read(os, value_obj, 0, sizeof(uint64_t),
+                   &stored_size, DMU_READ_PREFETCH);
+    if (err == 0 && stored_size > size) {
+        err = ERANGE;
+    } else if (err == 0) {
+        err = dmu_read(os, value_obj, sizeof(uint64_t),
+                       stored_size, value, DMU_READ_PREFETCH);
+    }
+    return err;
 }
 
 static int
 libuzfs_inode_get_kvattr_sa(const sa_attr_type_t *sa_tbl, sa_handle_t *sa_hdl,
-							const char *name, char *value, size_t size)
+                            const char *name, char *value, size_t size)
 {
-	nvlist_t *nvl;
-	int err = get_nvlist_from_handle(sa_tbl, &nvl, sa_hdl);
-	if (err != 0) {
-		return err;
-	}
+    nvlist_t *nvl;
+    int err = get_nvlist_from_handle(sa_tbl, &nvl, sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	uchar_t *nv_value;
-	uint_t nv_size = 0;
-	err = nvlist_lookup_byte_array(nvl, name, &nv_value, &nv_size);
-	if (err == 0 && nv_size <= size) {
-		if (value != NULL) {
-			memcpy(value, nv_value, nv_size);
-		}
-	}
-	nvlist_free(nvl);
+    uchar_t *nv_value;
+    uint_t nv_size = 0;
+    err = nvlist_lookup_byte_array(nvl, name, &nv_value, &nv_size);
+    if (err == 0 && nv_size <= size) {
+        if (value != NULL) {
+            memcpy(value, nv_value, nv_size);
+        }
+    }
+    nvlist_free(nvl);
 
-	if (nv_size > size) {
-		return ERANGE;
-	}
-	return err;
+    if (nv_size > size) {
+        return ERANGE;
+    }
+    return err;
 }
 
 int
 libuzfs_inode_get_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-    					 const char *name, char *value, uint64_t size,
-						 int flags)
+                         const char *name, char *value, uint64_t size,
+                         int flags)
 {
-	sa_handle_t	*sa_hdl;
-	int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
-	if (err != 0) {
-		return err;
-	}
+    sa_handle_t	*sa_hdl;
+    int err = sa_handle_get(dhp->os, ino, NULL, SA_HDL_PRIVATE, &sa_hdl);
+    if (err != 0) {
+        return err;
+    }
 
-	err = libuzfs_inode_get_kvattr_sa(dhp->uzfs_attr_table, sa_hdl,
-									  name, value, size);
-	if (err == 0 || err != ENOENT) {
-		goto out;
-	}
+    err = libuzfs_inode_get_kvattr_sa(dhp->uzfs_attr_table, sa_hdl,
+                                      name, value, size);
+    if (err == 0 || err != ENOENT) {
+        goto out;
+    }
 
-	err = libuzfs_inode_get_kvattr_dir(dhp->uzfs_attr_table, sa_hdl,
-									   name, value, size);
+    err = libuzfs_inode_get_kvattr_dir(dhp->uzfs_attr_table, sa_hdl,
+                                       name, value, size);
 
 out:
-	sa_handle_destroy(sa_hdl);
-	return err;
+    sa_handle_destroy(sa_hdl);
+    return err;
 }
 
 int
 libuzfs_inode_remove_kvattr(libuzfs_dataset_handle_t *dhp, uint64_t ino,
-							const char *name, uint64_t opid)
+                            const char *name, uint64_t opid)
 {
-	return libuzfs_inode_set_kvattr(dhp, ino, name, NULL, 0, 0, opid);
+    return libuzfs_inode_set_kvattr(dhp, ino, name, NULL, 0, 0, opid);
 }


### PR DESCRIPTION
the old implementation has poor compatibility and waste much space when storing xattr,
this pr solves that problem by using zfs system attribute
