### PR TITLE
fix(libuzfs): fix a bug which cause second import to returns ENOENT

### DIFF
--- a/lib/libuzfs/libuzfs.c
+++ b/lib/libuzfs/libuzfs.c
@@ -685,7 +685,9 @@ pool_active(void *unused, const char *name, uint64_t guid,
 static nvlist_t *
 refresh_config(void *unused, nvlist_t *tryconfig)
 {
-	return (spa_tryimport(tryconfig));
+	nvlist_t *res;
+	nvlist_dup(tryconfig, &res, KM_SLEEP);
+	return (res);
 }
 
 int


### PR DESCRIPTION
in former implementation, when zpool_import is called twice in a row, the second zpool_import returns ENOENT but not EEXIST