### PR TITLE
libuzfs & uzfs: object write grow blksz when needed

### DIFF
--- a/include/libuzfs_impl.h
+++ b/include/libuzfs_impl.h
@@ -47,6 +47,7 @@ struct libuzfs_dataset_handle {
 	objset_t *os;
 	zilog_t	*zilog;
 	uint64_t sb_ino;
+	uint64_t max_blksz;
 	sa_attr_type_t	*uzfs_attr_table;
 };
 


### PR DESCRIPTION
1. in object write, block size will increase if block size < file size and block size < 128k
2. split one write into reasonable size of chunks to keep zil small