### PR TITLE
libuzfs & uzfs: fix write throttle

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -343,7 +343,7 @@ char *zfs_deadman_failmode = "wait";
  * the worst case is:
  *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP * 2 == 24
  */
-int spa_asize_inflation = 24;
+int spa_asize_inflation = 1;
 
 /*
  * Normally, we don't allow the last 3.2% (1/(2^spa_slop_shift)) of space in


### PR DESCRIPTION
The default value of `spa_asize_inflation` is for worst case estimate, as we use ZBS as dev, so change to 1 to avoid write throttle.
