### PR TITLE
fix(dmu): preserve hole detection for uncompressed metadata

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1987,7 +1987,7 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 			compress = zio_compress_select(os->os_spa,
 			    ZIO_COMPRESS_ON, ZIO_COMPRESS_ON);
 		} else {
-			compress = ZIO_COMPRESS_OFF;
+			compress = ZIO_COMPRESS_EMPTY;
 		}
 		#endif
 


### PR DESCRIPTION
Use ZIO_COMPRESS_EMPTY and safely detect zero-filled ABD buffers.